### PR TITLE
Add leave group feature and improve dashboard layout

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -108,7 +108,7 @@ export default function DashboardPage() {
         </div>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <Card>
+          <Card className="flex flex-col">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Plus className="h-5 w-5" />
@@ -118,14 +118,14 @@ export default function DashboardPage() {
                 Partagez votre abonnement avec d&apos;autres membres
               </CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className="mt-auto">
               <CreateGroupDialog>
                 <Button className="w-full">Nouveau groupe</Button>
               </CreateGroupDialog>
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="flex flex-col">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Users className="h-5 w-5" />
@@ -135,7 +135,7 @@ export default function DashboardPage() {
                 Parcourez les offres disponibles
               </CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className="mt-auto">
               <Button
                 variant="outline"
                 className="w-full"
@@ -146,28 +146,18 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="flex flex-col">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Crown className="h-5 w-5" />
                 Mes groupes
               </CardTitle>
-              <CardDescription>
-                {groups.length} groupe{groups.length !== 1 ? "s" : ""} actif{groups.length !== 1 ? "s" : ""}
-              </CardDescription>
             </CardHeader>
-            <CardContent>
-              {loadingGroups ? (
-                <p className="text-sm text-muted-foreground">Chargement...</p>
-              ) : groups.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  Aucun groupe pour le moment
-                </p>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  {groups.length} groupe{groups.length !== 1 ? "s" : ""} ci-dessous
-                </p>
-              )}
+            <CardContent className="mt-auto">
+              <div className="flex items-end justify-between">
+                <p className="text-sm text-muted-foreground">Groupes actifs :</p>
+                <p className="text-6xl font-bold">{loadingGroups ? "—" : groups.length}</p>
+              </div>
             </CardContent>
           </Card>
         </div>

--- a/app/(protected)/groups/[id]/page.tsx
+++ b/app/(protected)/groups/[id]/page.tsx
@@ -90,6 +90,7 @@ export default function GroupDetailPage() {
   const [group, setGroup] = useState<GroupDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [joining, setJoining] = useState(false)
+  const [leaving, setLeaving] = useState(false)
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -134,6 +135,26 @@ export default function GroupDetailPage() {
       toast.error(err instanceof Error ? err.message : "Erreur")
     } finally {
       setJoining(false)
+    }
+  }
+
+  async function handleLeave() {
+    setLeaving(true)
+    try {
+      const res = await fetch(`/api/groups/${groupId}/leave`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+
+      toast.success("Vous avez quitté le groupe")
+      const refreshed = await fetch(`/api/groups/${groupId}`)
+      if (refreshed.ok) setGroup(await refreshed.json())
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erreur")
+    } finally {
+      setLeaving(false)
     }
   }
 
@@ -331,11 +352,22 @@ export default function GroupDetailPage() {
 
         {isMember && (
           <Card className="mt-6 border-green-200 dark:border-green-800">
-            <CardContent className="pt-6">
-              <p className="text-center text-green-600 font-medium flex items-center justify-center gap-2">
-                <CheckCircle className="h-5 w-5" />
-                Vous êtes membre de ce groupe
-              </p>
+            <CardContent>
+              <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+                <p className="text-green-600 font-medium flex items-center gap-2">
+                  <CheckCircle className="h-5 w-5" />
+                  Vous êtes membre de ce groupe
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={leaving}
+                  onClick={handleLeave}
+                  className="shrink-0 text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700 dark:border-red-800 dark:hover:bg-red-950"
+                >
+                  {leaving ? "En cours..." : "Quitter le groupe"}
+                </Button>
+              </div>
             </CardContent>
           </Card>
         )}

--- a/app/api/groups/[id]/leave/route.ts
+++ b/app/api/groups/[id]/leave/route.ts
@@ -1,0 +1,45 @@
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/db"
+import { verifyCsrf } from "@/lib/csrf"
+import { NextRequest, NextResponse } from "next/server"
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const csrfError = verifyCsrf(request)
+  if (csrfError) return csrfError
+
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const group = await prisma.group.findUnique({
+    where: { id },
+  })
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 })
+  }
+
+  if (group.ownerId === session.user.id) {
+    return NextResponse.json({ error: "Le propriétaire ne peut pas quitter son groupe" }, { status: 400 })
+  }
+
+  const member = await prisma.groupMember.findUnique({
+    where: { groupId_userId: { groupId: id, userId: session.user.id } },
+  })
+
+  if (!member) {
+    return NextResponse.json({ error: "Vous n'êtes pas membre de ce groupe" }, { status: 400 })
+  }
+
+  await prisma.groupMember.delete({
+    where: { groupId_userId: { groupId: id, userId: session.user.id } },
+  })
+
+  return NextResponse.json({ success: true })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -342,6 +343,7 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.13.tgz",
       "integrity": "sha512-+8OrU/9T9mkNNKCfTv9UMlNhl9qBKsXIS8d1JNrtuCkud8Ps0+jYvbBlwa90nFmDy8X96c9UIsq+eMhPs1SDXA==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.1.12"
@@ -371,12 +373,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
@@ -1864,6 +1868,7 @@
       "integrity": "sha512-QXFT+N/bva/QI2qoXmjBzL7D6aliPffIwP+81AdTGq0FXDoLxLkWivGMawG8iM5B9BKfxLIXxfWWAF6wbuJU6g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -4027,6 +4032,7 @@
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4037,6 +4043,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4087,6 +4094,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4617,6 +4625,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5029,6 +5038,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
       "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -5088,6 +5098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5756,7 +5767,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6065,6 +6077,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6250,6 +6263,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7562,6 +7576,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7663,6 +7678,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
       "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8124,6 +8140,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -8156,6 +8173,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.2.tgz",
       "integrity": "sha512-SVSWX7wjUUDrIDVqhl4xm/jiOrvYGMG7NzVE/dGzzgs7r3dFGm4V19ia0xn3GDNtHCKM7C9h+5BoimnJBhmt9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.2",
         "@swc/helpers": "0.5.15",
@@ -8614,6 +8632,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.0",
         "@prisma/engines": "6.19.0"
@@ -8714,6 +8733,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8744,6 +8764,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8756,6 +8777,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
       "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9713,6 +9735,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9904,6 +9927,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10287,6 +10311,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Add a new API endpoint (`POST /api/groups/[id]/leave`) allowing members to leave a group, with CSRF protection and ownership guard
- Add a "Quitter le groupe" button on the group detail page for current members
- Improve dashboard card layout so buttons are consistently pinned to the bottom of their cards
- Redesign the "Mes groupes" card to show a large active group count

## Test plan
- [ ] Verify a member can leave a group and the UI updates correctly
- [ ] Verify the group owner cannot leave their own group
- [ ] Verify dashboard cards are vertically aligned with buttons at the bottom
- [ ] Verify the "Mes groupes" card displays the correct count